### PR TITLE
Updated result field on CopyFileData to be a String.

### DIFF
--- a/src/main/java/com/uploadcare/data/CopyFileData.java
+++ b/src/main/java/com/uploadcare/data/CopyFileData.java
@@ -7,11 +7,11 @@ package com.uploadcare.data;
 public class CopyFileData {
 	public String detail;
 	public String type;
-	public FileData result;
+	public String result;
 
 	@Override
 	public String toString() {
-		return "detail: " + (detail == null ? "" : detail) + ", type: " + (type == null ? "" : type) + ", result: " + (result == null ? "" : result.uuid);
+		return "detail: " + (detail == null ? "" : detail) + ", type: " + (type == null ? "" : type) + ", result: " + (result == null ? "" : result);
 	}
 	
 }


### PR DESCRIPTION
The ObjectMapper is unable to process CopyFileData response because data field is of type `String` and not of `FileData`:

Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not instantiate value of type [simple type, class com.uploadcare.data.FileData] from String value ('s3://foobar/uploadcare/80a58309-d300-4ecd-a54d-a95fb50054f4.wav'); no single-String constructor/factory method
 at [Source: {"type":"url","result":"s3://foobar/uploadcare/80a58309-d300-4ecd-a54d-a95fb50054f4.wav"}; line: 1, column: 24](through reference chain: com.uploadcare.data.CopyFileData["result"])
