### PR TITLE
Add support for InputStreams, updated deprecated code

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,9 +1,11 @@
 # git log --format='%aN <%aE>' | sort -u
 
-Alexander Tchernin <alchernin@gmail.com>
+alchernin <alchernin@gmail.com>
+Artemis <artemix@artemix.org>
 Dimitry Solovyov <dimituri@gmail.com>
 Dmitry Mukhin <dm@uploadcare.com>
 Elijah <ilya@uploadcare.com>
-Raphael Gilyazitdinov <iraphaele@gmail.com>
-Joseph Mason <joeyvmason@gmail.com>
+GIlyazitdinov Raphael <iraphaele@gmail.com>
+joeyvmason <joeyvmason@gmail.com>
+Valeriy.Vyrva <valery1707@gmail.com>
 Yervand Aghababyan <yervand.aghababyan@sflpro.com>

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/uploadcare/upload/FileUploader.java
+++ b/src/main/java/com/uploadcare/upload/FileUploader.java
@@ -6,10 +6,9 @@ import com.uploadcare.data.UploadBaseData;
 import com.uploadcare.urls.Urls;
 
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.entity.mime.content.StringBody;
 
 import java.net.URI;
 
@@ -67,17 +66,15 @@ public class FileUploader implements Uploader {
         URI uploadUrl = Urls.uploadBase();
         HttpPost request = new HttpPost(uploadUrl);
 
-        MultipartEntity entity = new MultipartEntity();
-        StringBody pubKeyBody = StringBody.create(client.getPublicKey(), "text/plain", null);
-        StringBody storeBody = StringBody.create(store, "text/plain", null);
-        entity.addPart("UPLOADCARE_PUB_KEY", pubKeyBody);
-        entity.addPart("UPLOADCARE_STORE", storeBody);
+        MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
+        entityBuilder.addTextBody("UPLOADCARE_PUB_KEY", client.getPublicKey());
+        entityBuilder.addTextBody("UPLOADCARE_STORE", store);
         if (file != null) {
-            entity.addPart("file", new FileBody(file));
+            entityBuilder.addPart("file", new FileBody(file));
         } else {
-            entity.addPart("file", new ByteArrayBody(bytes, filename));
+            entityBuilder.addPart("file", new ByteArrayBody(bytes, filename));
         }
-        request.setEntity(entity);
+        request.setEntity(entityBuilder.build());
 
         String fileId = client.getRequestHelper()
                 .executeQuery(request, false, UploadBaseData.class).file;

--- a/src/main/java/com/uploadcare/upload/FileUploader.java
+++ b/src/main/java/com/uploadcare/upload/FileUploader.java
@@ -10,6 +10,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.entity.mime.content.FileBody;
 
+import java.io.InputStream;
 import java.net.URI;
 
 /**
@@ -20,6 +21,8 @@ public class FileUploader implements Uploader {
     private final Client client;
 
     private final java.io.File file;
+
+    private final InputStream stream;
 
     private final byte[] bytes;
 
@@ -37,6 +40,7 @@ public class FileUploader implements Uploader {
     public FileUploader(Client client, java.io.File file) {
         this.client = client;
         this.file = file;
+        this.stream = null;
         this.bytes = null;
         this.filename = null;
     }
@@ -51,7 +55,16 @@ public class FileUploader implements Uploader {
     public FileUploader(Client client, byte[] bytes, String filename) {
         this.client = client;
         this.file = null;
+        this.stream = null;
         this.bytes = bytes;
+        this.filename = filename;
+    }
+
+    public FileUploader(Client client, InputStream stream, String filename) {
+        this.client = client;
+        this.file = null;
+        this.stream = stream;
+        this.bytes = null;
         this.filename = filename;
     }
 
@@ -71,6 +84,8 @@ public class FileUploader implements Uploader {
         entityBuilder.addTextBody("UPLOADCARE_STORE", store);
         if (file != null) {
             entityBuilder.addPart("file", new FileBody(file));
+        } else if (stream != null) {
+            entityBuilder.addBinaryBody("file", stream);
         } else {
             entityBuilder.addPart("file", new ByteArrayBody(bytes, filename));
         }


### PR DESCRIPTION
*From #16*

I implemented support for InputStreams in the FileUploader, but a question arise for me:
Wouldn't a FileUploader API redesign be better ?

There's a mess between 3 constructors, and a lot of unused private attributes, and I think that redesigning it to instead have some kind of helper/builder could help avoid that.
Something that'd build the Part or add itself to the built part instead of having a lot of constructors.

I also had to update the Maven target version to 1.6 since the 1.5 version was not supported anymore.