### PR TITLE
Add missing property in ImageInfo and feature un CdnPathBuilder

### DIFF
--- a/src/main/java/com/uploadcare/api/File.java
+++ b/src/main/java/com/uploadcare/api/File.java
@@ -171,6 +171,7 @@ public class File {
         public ColorMode colorMode;
         public GeoLocation geoLocation;
         public List<Float> dpi;
+        public Date datetimeOriginal;
 
         @Override
         public String toString() {
@@ -183,6 +184,7 @@ public class File {
                     ", colorMode=" + colorMode +
                     ", geoLocation=" + geoLocation +
                     ", dpi=" + dpi +
+                    ", datetimeOriginal=" + datetimeOriginal +
                     '}';
         }
     }

--- a/src/main/java/com/uploadcare/urls/CdnPathBuilder.java
+++ b/src/main/java/com/uploadcare/urls/CdnPathBuilder.java
@@ -342,6 +342,15 @@ public class CdnPathBuilder {
     }
 
     /**
+     * Runs faces detection on the image
+     *
+     */
+    public CdnPathBuilder detectFaces() {
+        this.sb.append("/detect_faces");
+        return this;
+    }
+
+    /**
      * Returns the current CDN path as a string.
      *
      * Avoid using directly.

--- a/src/test/java/com/uploadcare/urls/CdnPathBuilderTest.java
+++ b/src/test/java/com/uploadcare/urls/CdnPathBuilderTest.java
@@ -82,6 +82,12 @@ public class CdnPathBuilderTest {
     }
 
     @Test
+    public void test_detectFaces() {
+        String path = builder.detectFaces().build();
+        assertEquals("/" + FILE_ID + "/detect_faces/", path);
+    }
+
+    @Test
     public void test_dimensionGuard() {
         builder.resizeWidth(1);
         builder.resizeWidth(2048);


### PR DESCRIPTION
Add datetimeOriginal in ImageInfo 
Add face detection to CdnPathBuilder

## Description

The file information API returns the originalDatetime from the Exif metadata but the client was ignoring it (https://uploadcare.com/docs/delivery/cdn/#file-info)

I also added /detect_faces to the CdnPathBuilder but I'm not sure this is something you want in the client


## Checklist

- [X ] Tests (if applicable)
