### PR TITLE
Expand file size property from int to long 

### DIFF
--- a/src/main/java/com/uploadcare/api/File.java
+++ b/src/main/java/com/uploadcare/api/File.java
@@ -53,7 +53,7 @@ public class File {
         return fileData.datetimeRemoved;
     }
 
-    public int getSize() {
+    public long getSize() {
         return fileData.size;
     }
 

--- a/src/main/java/com/uploadcare/data/FileData.java
+++ b/src/main/java/com/uploadcare/data/FileData.java
@@ -10,7 +10,7 @@ public class FileData {
 
     public String uuid;
     public URI url;
-    public int size;
+    public long size;
     public String source;
     public boolean isReady;
     public boolean isImage;


### PR DESCRIPTION
Expand file size property from int to long to fix issue with reading files that are larger than 2.1 GB.

## Description
Currently, when reading files greater than 2147483647 bytes (~2.1 GB) via Client.getFiles(), I get the following error:
com.fasterxml.jackson.core.exc.InputCoercionException: Numeric value (2163264498) out of range of int (-2147483648 - 2147483647)
...
! Causing: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (2163264498) out of range of int (-2147483648 - 2147483647)
!  at [Source: (StringReader); line: 1, column: 67438] (through reference chain: com.uploadcare.data.FilePageData["results"]->java.util.ArrayList[98]->com.uploadcare.data.FileData["size"])

<!-- Write a brief description of the changes introduced by this PR -->
This change changes the size property from type int to long to fix this issue.
NOTE: this is a breaking change, because it is changing the interface of the output.
